### PR TITLE
Update to mozilla central commit fc6124f09abd.

### DIFF
--- a/gmp-entrypoints.h
+++ b/gmp-entrypoints.h
@@ -40,9 +40,11 @@
 /* C functions exposed by Gecko Media Plugin shared library. */
 
 // GMPInit
-// - Called once after plugin library is loaded, before GMPGetAPI or GMPShutdown are called.
+// - Called once after plugin library is loaded, before GMPGetAPI or GMPShutdown
+// are called.
 // - Called on main thread.
-// - 'aPlatformAPI' is a structure containing platform-provided APIs. It is valid until
+// - 'aPlatformAPI' is a structure containing platform-provided APIs. It is
+// valid until
 //   'GMPShutdown' is called. Owned and must be deleted by plugin.
 typedef GMPErr (*GMPInitFunc)(const GMPPlatformAPI* aPlatformAPI);
 
@@ -55,15 +57,17 @@ typedef GMPErr (*GMPInitFunc)(const GMPPlatformAPI* aPlatformAPI);
 //   make sure you compare aAPIName against the corresponding GMP_API_* macro!
 // - 'aHostAPI' is the host API which is specific to the API being requested
 //   from the plugin. It is valid so long as the API object requested from the
-//   plugin is valid. It is owned by the host, plugin should not attempt to delete.
-//   May be null.
-// - 'aPluginAPI' is for returning the requested API. Destruction of the requsted
+//   plugin is valid. It is owned by the host, plugin should not attempt to
+//   delete. May be null.
+// - 'aPluginAPI' is for returning the requested API. Destruction of the
+// requsted
 //   API object is defined by the API.
-typedef GMPErr (*GMPGetAPIFunc)(const char* aAPIName, void* aHostAPI, void** aPluginAPI);
+typedef GMPErr (*GMPGetAPIFunc)(const char* aAPIName, void* aHostAPI,
+                                void** aPluginAPI);
 
 // GMPShutdown
 // - Called once before exiting process (unloading library).
 // - Called on main thread.
-typedef void   (*GMPShutdownFunc)(void);
+typedef void (*GMPShutdownFunc)(void);
 
-#endif // GMP_ENTRYPOINTS_h_
+#endif  // GMP_ENTRYPOINTS_h_

--- a/gmp-errors.h
+++ b/gmp-errors.h
@@ -49,10 +49,11 @@ typedef enum {
   GMPInvalidArgErr = 12,
   GMPAbortedErr = 13,
   GMPRecordCorrupted = 14,
-  GMPLastErr // Placeholder, must be last. This enum's values must remain consecutive!
+  GMPLastErr  // Placeholder, must be last. This enum's values must remain
+              // consecutive!
 } GMPErr;
 
 #define GMP_SUCCEEDED(x) ((x) == GMPNoErr)
 #define GMP_FAILED(x) ((x) != GMPNoErr)
 
-#endif // GMP_ERRORS_h_
+#endif  // GMP_ERRORS_h_

--- a/gmp-platform.h
+++ b/gmp-platform.h
@@ -40,27 +40,27 @@
 /* Platform helper API. */
 
 class GMPTask {
-public:
-  virtual void Destroy() = 0; // Deletes object.
-  virtual ~GMPTask() {}
+ public:
+  virtual void Destroy() = 0;  // Deletes object.
+  virtual ~GMPTask() = default;
   virtual void Run() = 0;
 };
 
 class GMPThread {
-public:
-  virtual ~GMPThread() {}
+ public:
+  virtual ~GMPThread() = default;
   virtual void Post(GMPTask* aTask) = 0;
-  virtual void Join() = 0; // Deletes object after join completes.
+  virtual void Join() = 0;  // Deletes object after join completes.
 };
 
 // A re-entrant monitor; can be locked from the same thread multiple times.
 // Must be unlocked the same number of times it's locked.
 class GMPMutex {
-public:
-  virtual ~GMPMutex() {}
+ public:
+  virtual ~GMPMutex() = default;
   virtual void Acquire() = 0;
   virtual void Release() = 0;
-  virtual void Destroy() = 0; // Deletes object.
+  virtual void Destroy() = 0;  // Deletes object.
 };
 
 // Time is defined as the number of milliseconds since the
@@ -79,7 +79,8 @@ typedef GMPErr (*GMPCreateRecordPtr)(const char* aRecordName,
                                      GMPRecordClient* aClient);
 
 // Call on main thread only.
-typedef GMPErr (*GMPSetTimerOnMainThreadPtr)(GMPTask* aTask, int64_t aTimeoutMS);
+typedef GMPErr (*GMPSetTimerOnMainThreadPtr)(GMPTask* aTask,
+                                             int64_t aTimeoutMS);
 typedef GMPErr (*GMPGetCurrentTimePtr)(GMPTimestamp* aOutTime);
 
 struct GMPPlatformAPI {
@@ -87,7 +88,7 @@ struct GMPPlatformAPI {
   // do not change what already exists. Pointers to functions may be NULL
   // when passed to plugins, but beware backwards compat implications of
   // doing that.
-  uint16_t version; // Currently version 0
+  uint16_t version;  // Currently version 0
 
   GMPCreateThreadPtr createthread;
   GMPRunOnMainThreadPtr runonmainthread;
@@ -98,4 +99,4 @@ struct GMPPlatformAPI {
   GMPGetCurrentTimePtr getcurrenttime;
 };
 
-#endif // GMP_PLATFORM_h_
+#endif  // GMP_PLATFORM_h_

--- a/gmp-sanitized-cdm-exports.h
+++ b/gmp-sanitized-cdm-exports.h
@@ -1,0 +1,22 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This file exposes symbols from the CDM headers + undefines macros which
+// X11 defines and which clash with the CDM headers.
+//
+// Ideally we can prune where X11 headers are included so that we don't need
+// this, but this band aid is useful until then.
+
+#ifndef DOM_MEDIA_GMP_GMP_API_GMP_SANITIZED_CDM_EXPORTS_H_
+#define DOM_MEDIA_GMP_GMP_API_GMP_SANITIZED_CDM_EXPORTS_H_
+
+// If Status is defined undef it so we don't break the CDM headers.
+#ifdef Status
+#  undef Status
+#endif  // Status
+#include "content_decryption_module.h"
+
+#endif  // DOM_MEDIA_GMP_GMP_API_GMP_SANITIZED_CDM_EXPORTS_H_

--- a/gmp-storage.h
+++ b/gmp-storage.h
@@ -1,18 +1,18 @@
 /*
-* Copyright 2013, Mozilla Foundation and contributors
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2013, Mozilla Foundation and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef GMP_STORAGE_h_
 #define GMP_STORAGE_h_
@@ -40,8 +40,7 @@
 // GMPRecord to delete the GMPRecord object's memory. If your GMP does not
 // call Close(), the GMPRecord's memory will leak.
 class GMPRecord {
-public:
-
+ public:
   // Opens the record. Calls OpenComplete() once the record is open.
   // Note: Only work when GMP is loading content from a webserver.
   // Does not work for web pages on loaded from disk.
@@ -65,14 +64,13 @@ public:
   // callbacks.
   virtual GMPErr Close() = 0;
 
-  virtual ~GMPRecord() {}
+  virtual ~GMPRecord() = default;
 };
 
 // Callback object that receives the results of GMPRecord calls. Callbacks
 // run asynchronously to the GMPRecord call, on the main thread.
 class GMPRecordClient {
  public:
-
   // Response to a GMPRecord::Open() call with the open |status|.
   // aStatus values:
   // - GMPNoErr - Record opened successfully. Record may be empty.
@@ -94,8 +92,7 @@ class GMPRecordClient {
   // - GMPGenericErr - Unspecified error.
   // If aStatus is not GMPNoErr, the GMPRecord is unusable, and you must
   // call Close() on the GMPRecord to dispose of it.
-  virtual void ReadComplete(GMPErr aStatus,
-                            const uint8_t* aData,
+  virtual void ReadComplete(GMPErr aStatus, const uint8_t* aData,
                             uint32_t aDataSize) = 0;
 
   // Response to a GMPRecord::Write() call.
@@ -107,7 +104,7 @@ class GMPRecordClient {
   // call Close() on the GMPRecord to dispose of it.
   virtual void WriteComplete(GMPErr aStatus) = 0;
 
-  virtual ~GMPRecordClient() {}
+  virtual ~GMPRecordClient() = default;
 };
 
-#endif // GMP_STORAGE_h_
+#endif  // GMP_STORAGE_h_

--- a/gmp-video-codec.h
+++ b/gmp-video-codec.h
@@ -37,33 +37,31 @@
 #include <stdint.h>
 #include <stddef.h>
 
-enum { kGMPPayloadNameSize = 32};
-enum { kGMPMaxSimulcastStreams = 4};
+enum { kGMPPayloadNameSize = 32 };
+enum { kGMPMaxSimulcastStreams = 4 };
 
-enum GMPVideoCodecComplexity
-{
+enum GMPVideoCodecComplexity {
   kGMPComplexityNormal = 0,
   kGMPComplexityHigh = 1,
   kGMPComplexityHigher = 2,
   kGMPComplexityMax = 3,
-  kGMPComplexityInvalid // Should always be last
+  kGMPComplexityInvalid  // Should always be last
 };
 
 enum GMPVP8ResilienceMode {
-  kResilienceOff,    // The stream produced by the encoder requires a
-                     // recovery frame (typically a key frame) to be
-                     // decodable after a packet loss.
-  kResilientStream,  // A stream produced by the encoder is resilient to
-                     // packet losses, but packets within a frame subsequent
-                     // to a loss can't be decoded.
-  kResilientFrames,  // Same as kResilientStream but with added resilience
-                     // within a frame.
-  kResilienceInvalid // Should always be last.
+  kResilienceOff,     // The stream produced by the encoder requires a
+                      // recovery frame (typically a key frame) to be
+                      // decodable after a packet loss.
+  kResilientStream,   // A stream produced by the encoder is resilient to
+                      // packet losses, but packets within a frame subsequent
+                      // to a loss can't be decoded.
+  kResilientFrames,   // Same as kResilientStream but with added resilience
+                      // within a frame.
+  kResilienceInvalid  // Should always be last.
 };
 
 // VP8 specific
-struct GMPVideoCodecVP8
-{
+struct GMPVideoCodecVP8 {
   bool mPictureLossIndicationOn;
   bool mFeedbackModeOn;
   GMPVideoCodecComplexity mComplexity;
@@ -78,19 +76,20 @@ struct GMPVideoCodecVP8
 
 // Needs to match a binary spec for this structure.
 // Note: the mSPS at the end of this structure is variable length.
-struct GMPVideoCodecH264AVCC
-{
-  uint8_t        mVersion; // == 0x01
-  uint8_t        mProfile; // these 3 are profile_level_id
-  uint8_t        mConstraints;
-  uint8_t        mLevel;
-  uint8_t        mLengthSizeMinusOne; // lower 2 bits (== GMPBufferType-1). Top 6 reserved (1's)
+struct GMPVideoCodecH264AVCC {
+  uint8_t mVersion;  // == 0x01
+  uint8_t mProfile;  // these 3 are profile_level_id
+  uint8_t mConstraints;
+  uint8_t mLevel;
+  uint8_t mLengthSizeMinusOne;  // lower 2 bits (== GMPBufferType-1). Top 6
+                                // reserved (1's)
 
   // SPS/PPS will not generally be present for interactive use unless SDP
   // parameter-sets are used.
-  uint8_t        mNumSPS; // lower 5 bits; top 5 reserved (1's)
+  uint8_t mNumSPS;  // lower 5 bits; top 5 reserved (1's)
 
-  /*** uint8_t   mSPS[];  (Not defined due to compiler warnings and warnings-as-errors ...) **/
+  /*** uint8_t   mSPS[];  (Not defined due to compiler warnings and
+   * warnings-as-errors ...) **/
   // Following mNumSPS is a variable number of bytes, which is the SPS and PPS.
   // Each SPS == 16 bit size, ("N"), then "N" bytes,
   // then uint8_t mNumPPS, then each PPS == 16 bit size ("N"), then "N" bytes.
@@ -99,14 +98,13 @@ struct GMPVideoCodecH264AVCC
 // Codec specific data for H.264 decoding/encoding.
 // Cast the "aCodecSpecific" parameter of GMPVideoDecoder::InitDecode() and
 // GMPVideoEncoder::InitEncode() to this structure.
-struct GMPVideoCodecH264
-{
-  uint8_t        mPacketizationMode; // 0 or 1
-  struct GMPVideoCodecH264AVCC mAVCC; // holds a variable-sized struct GMPVideoCodecH264AVCC mAVCC;
+struct GMPVideoCodecH264 {
+  uint8_t mPacketizationMode;  // 0 or 1
+  struct GMPVideoCodecH264AVCC
+      mAVCC;  // holds a variable-sized struct GMPVideoCodecH264AVCC mAVCC;
 };
 
-enum GMPVideoCodecType
-{
+enum GMPVideoCodecType {
   kGMPVideoCodecVP8,
 
   // Encoded frames are in AVCC format; NAL length field of 4 bytes, followed
@@ -114,48 +112,47 @@ enum GMPVideoCodecType
   // is the AVCC extra data (in AVCC format).
   kGMPVideoCodecH264,
   kGMPVideoCodecVP9,
-  kGMPVideoCodecInvalid // Should always be last.
+  kGMPVideoCodecInvalid  // Should always be last.
 };
 
 // Simulcast is when the same stream is encoded multiple times with different
 // settings such as resolution.
-struct GMPSimulcastStream
-{
+struct GMPSimulcastStream {
   uint32_t mWidth;
   uint32_t mHeight;
   uint32_t mNumberOfTemporalLayers;
-  uint32_t mMaxBitrate; // kilobits/sec.
-  uint32_t mTargetBitrate; // kilobits/sec.
-  uint32_t mMinBitrate; // kilobits/sec.
-  uint32_t mQPMax; // minimum quality
+  uint32_t mMaxBitrate;     // kilobits/sec.
+  uint32_t mTargetBitrate;  // kilobits/sec.
+  uint32_t mMinBitrate;     // kilobits/sec.
+  uint32_t mQPMax;          // minimum quality
 };
 
 enum GMPVideoCodecMode {
   kGMPRealtimeVideo,
   kGMPScreensharing,
   kGMPStreamingVideo,
-  kGMPCodecModeInvalid // Should always be last.
+  kGMPCodecModeInvalid  // Should always be last.
 };
 
 enum GMPApiVersion {
-  kGMPVersion32 = 1, // leveraging that V32 had mCodecType first, and only supported H264
+  kGMPVersion32 =
+      1,  // leveraging that V32 had mCodecType first, and only supported H264
   kGMPVersion33 = 33,
 };
 
-struct GMPVideoCodec
-{
+struct GMPVideoCodec {
   uint32_t mGMPApiVersion;
 
   GMPVideoCodecType mCodecType;
-  char mPLName[kGMPPayloadNameSize]; // Must be NULL-terminated!
+  char mPLName[kGMPPayloadNameSize];  // Must be NULL-terminated!
   uint32_t mPLType;
 
   uint32_t mWidth;
   uint32_t mHeight;
 
-  uint32_t mStartBitrate; // kilobits/sec.
-  uint32_t mMaxBitrate; // kilobits/sec.
-  uint32_t mMinBitrate; // kilobits/sec.
+  uint32_t mStartBitrate;  // kilobits/sec.
+  uint32_t mMaxBitrate;    // kilobits/sec.
+  uint32_t mMinBitrate;    // kilobits/sec.
   uint32_t mMaxFramerate;
 
   bool mFrameDroppingOn;
@@ -191,23 +188,21 @@ struct GMPCodecSpecificInfoH264 {
 
 // Note: if any pointers are added to this struct, it must be fitted
 // with a copy-constructor. See below.
-struct GMPCodecSpecificInfoVP8
-{
+struct GMPCodecSpecificInfoVP8 {
   bool mHasReceivedSLI;
   uint8_t mPictureIdSLI;
   bool mHasReceivedRPSI;
   uint64_t mPictureIdRPSI;
-  int16_t mPictureId; // negative value to skip pictureId
+  int16_t mPictureId;  // negative value to skip pictureId
   bool mNonReference;
   uint8_t mSimulcastIdx;
   uint8_t mTemporalIdx;
   bool mLayerSync;
-  int32_t mTL0PicIdx; // negative value to skip tl0PicIdx
-  int8_t mKeyIdx; // negative value to skip keyIdx
+  int32_t mTL0PicIdx;  // negative value to skip tl0PicIdx
+  int8_t mKeyIdx;      // negative value to skip keyIdx
 };
 
-union GMPCodecSpecificInfoUnion
-{
+union GMPCodecSpecificInfoUnion {
   GMPCodecSpecificInfoGeneric mGeneric;
   GMPCodecSpecificInfoVP8 mVP8;
   GMPCodecSpecificInfoH264 mH264;
@@ -216,11 +211,10 @@ union GMPCodecSpecificInfoUnion
 // Note: if any pointers are added to this struct or its sub-structs, it
 // must be fitted with a copy-constructor. This is because it is copied
 // in the copy-constructor of VCMEncodedFrame.
-struct GMPCodecSpecificInfo
-{
+struct GMPCodecSpecificInfo {
   GMPVideoCodecType mCodecType;
   GMPBufferType mBufferType;
   GMPCodecSpecificInfoUnion mCodecSpecific;
 };
 
-#endif // GMP_VIDEO_CODEC_h_
+#endif  // GMP_VIDEO_CODEC_h_

--- a/gmp-video-decode.h
+++ b/gmp-video-decode.h
@@ -41,9 +41,8 @@
 #include <stdint.h>
 
 // ALL METHODS MUST BE CALLED ON THE MAIN THREAD
-class GMPVideoDecoderCallback
-{
-public:
+class GMPVideoDecoderCallback {
+ public:
   virtual ~GMPVideoDecoderCallback() {}
 
   virtual void Decoded(GMPVideoi420Frame* aDecodedFrame) = 0;
@@ -72,9 +71,8 @@ public:
 // Host API: GMPVideoHost
 //
 // ALL METHODS MUST BE CALLED ON THE MAIN THREAD
-class GMPVideoDecoder
-{
-public:
+class GMPVideoDecoder {
+ public:
   virtual ~GMPVideoDecoder() {}
 
   // - aCodecSettings: Details of decoder to create.
@@ -82,7 +80,8 @@ public:
   //                   to get codec specific config data.
   // - aCodecSpecificLength: number of bytes in aCodecSpecific.
   // - aCallback: Subclass should retain reference to it until DecodingComplete
-  //              is called. Do not attempt to delete it, host retains ownership.
+  //              is called. Do not attempt to delete it, host retains
+  //              ownership.
   // aCoreCount: number of CPU cores.
   virtual void InitDecode(const GMPVideoCodec& aCodecSettings,
                           const uint8_t* aCodecSpecific,
@@ -102,8 +101,7 @@ public:
   // - aCodecSpecificInfoLength : number of bytes in aCodecSpecificInfo
   // - renderTimeMs : System time to render in milliseconds. Only used by
   //                  decoders with internal rendering.
-  virtual void Decode(GMPVideoEncodedFrame* aInputFrame,
-                      bool aMissingFrames,
+  virtual void Decode(GMPVideoEncodedFrame* aInputFrame, bool aMissingFrames,
                       const uint8_t* aCodecSpecificInfo,
                       uint32_t aCodecSpecificInfoLength,
                       int64_t aRenderTimeMs = -1) = 0;
@@ -124,4 +122,4 @@ public:
   virtual void DecodingComplete() = 0;
 };
 
-#endif // GMP_VIDEO_DECODE_h_
+#endif  // GMP_VIDEO_DECODE_h_

--- a/gmp-video-encode.h
+++ b/gmp-video-encode.h
@@ -43,9 +43,8 @@
 #include "gmp-video-codec.h"
 
 // ALL METHODS MUST BE CALLED ON THE MAIN THREAD
-class GMPVideoEncoderCallback
-{
-public:
+class GMPVideoEncoderCallback {
+ public:
   virtual ~GMPVideoEncoderCallback() {}
 
   virtual void Encoded(GMPVideoEncodedFrame* aEncodedFrame,
@@ -66,9 +65,8 @@ public:
 // Host API: GMPVideoHost
 //
 // ALL METHODS MUST BE CALLED ON THE MAIN THREAD
-class GMPVideoEncoder
-{
-public:
+class GMPVideoEncoder {
+ public:
   virtual ~GMPVideoEncoder() {}
 
   // Initialize the encoder with the information from the VideoCodec.
@@ -80,7 +78,8 @@ public:
   //                    this codec type.
   // - aCodecSpecificLength : number of bytes in aCodecSpecific
   // - aCallback: Subclass should retain reference to it until EncodingComplete
-  //              is called. Do not attempt to delete it, host retains ownership.
+  //              is called. Do not attempt to delete it, host retains
+  //              ownership.
   // - aNnumberOfCores : Number of cores available for the encoder
   // - aMaxPayloadSize : The maximum size each payload is allowed
   //                    to have. Usually MTU - overhead.
@@ -88,8 +87,7 @@ public:
                           const uint8_t* aCodecSpecific,
                           uint32_t aCodecSpecificLength,
                           GMPVideoEncoderCallback* aCallback,
-                          int32_t aNumberOfCores,
-                          uint32_t aMaxPayloadSize) = 0;
+                          int32_t aNumberOfCores, uint32_t aMaxPayloadSize) = 0;
 
   // Encode an I420 frame (as a part of a video stream). The encoded frame
   // will be returned to the user through the encode complete callback.
@@ -122,8 +120,8 @@ public:
   // - frameRate : The target frame rate
   virtual void SetRates(uint32_t aNewBitRate, uint32_t aFrameRate) = 0;
 
-  // Use this function to enable or disable periodic key frames. Can be useful for codecs
-  // which have other ways of stopping error propagation.
+  // Use this function to enable or disable periodic key frames. Can be useful
+  // for codecs which have other ways of stopping error propagation.
   //
   // - enable : Enable or disable periodic key frames
   virtual void SetPeriodicKeyFrames(bool aEnable) = 0;
@@ -132,4 +130,4 @@ public:
   virtual void EncodingComplete() = 0;
 };
 
-#endif // GMP_VIDEO_ENCODE_h_
+#endif  // GMP_VIDEO_ENCODE_h_

--- a/gmp-video-frame-encoded.h
+++ b/gmp-video-frame-encoded.h
@@ -38,14 +38,13 @@
 #include "gmp-video-frame.h"
 #include "gmp-video-codec.h"
 
-enum GMPVideoFrameType
-{
+enum GMPVideoFrameType {
   kGMPKeyFrame = 0,
   kGMPDeltaFrame = 1,
   kGMPGoldenFrame = 2,
   kGMPAltRefFrame = 3,
   kGMPSkipFrame = 4,
-  kGMPVideoFrameInvalid = 5 // Must always be last.
+  kGMPVideoFrameInvalid = 5  // Must always be last.
 };
 
 // The implementation backing this interface uses shared memory for the
@@ -57,38 +56,37 @@ enum GMPVideoFrameType
 //
 // Methods that create or destroy shared memory must be called on the main
 // thread. They are marked below.
-class GMPVideoEncodedFrame : public GMPVideoFrame
-{
-public:
+class GMPVideoEncodedFrame : public GMPVideoFrame {
+ public:
   // MAIN THREAD ONLY
   virtual GMPErr CreateEmptyFrame(uint32_t aSize) = 0;
   // MAIN THREAD ONLY
   virtual GMPErr CopyFrame(const GMPVideoEncodedFrame& aVideoFrame) = 0;
-  virtual void     SetEncodedWidth(uint32_t aEncodedWidth) = 0;
+  virtual void SetEncodedWidth(uint32_t aEncodedWidth) = 0;
   virtual uint32_t EncodedWidth() = 0;
-  virtual void     SetEncodedHeight(uint32_t aEncodedHeight) = 0;
+  virtual void SetEncodedHeight(uint32_t aEncodedHeight) = 0;
   virtual uint32_t EncodedHeight() = 0;
   // Microseconds
-  virtual void     SetTimeStamp(uint64_t aTimeStamp) = 0;
+  virtual void SetTimeStamp(uint64_t aTimeStamp) = 0;
   virtual uint64_t TimeStamp() = 0;
   // Set frame duration (microseconds)
   // NOTE: next-frame's Timestamp() != this-frame's TimeStamp()+Duration()
   // depending on rounding to avoid having to track roundoff errors
   // and dropped/missing frames(!) (which may leave a large gap)
-  virtual void     SetDuration(uint64_t aDuration) = 0;
+  virtual void SetDuration(uint64_t aDuration) = 0;
   virtual uint64_t Duration() const = 0;
-  virtual void     SetFrameType(GMPVideoFrameType aFrameType) = 0;
+  virtual void SetFrameType(GMPVideoFrameType aFrameType) = 0;
   virtual GMPVideoFrameType FrameType() = 0;
-  virtual void     SetAllocatedSize(uint32_t aNewSize) = 0;
+  virtual void SetAllocatedSize(uint32_t aNewSize) = 0;
   virtual uint32_t AllocatedSize() = 0;
-  virtual void     SetSize(uint32_t aSize) = 0;
+  virtual void SetSize(uint32_t aSize) = 0;
   virtual uint32_t Size() = 0;
-  virtual void     SetCompleteFrame(bool aCompleteFrame) = 0;
-  virtual bool     CompleteFrame() = 0;
+  virtual void SetCompleteFrame(bool aCompleteFrame) = 0;
+  virtual bool CompleteFrame() = 0;
   virtual const uint8_t* Buffer() const = 0;
-  virtual uint8_t*       Buffer() = 0;
-  virtual GMPBufferType  BufferType() const = 0;
-  virtual void     SetBufferType(GMPBufferType aBufferType) = 0;
+  virtual uint8_t* Buffer() = 0;
+  virtual GMPBufferType BufferType() const = 0;
+  virtual void SetBufferType(GMPBufferType aBufferType) = 0;
 };
 
-#endif // GMP_VIDEO_FRAME_ENCODED_h_
+#endif  // GMP_VIDEO_FRAME_ENCODED_h_

--- a/gmp-video-frame-i420.h
+++ b/gmp-video-frame-i420.h
@@ -57,14 +57,15 @@ enum GMPPlaneType {
 // Methods that create or destroy shared memory must be called on the main
 // thread. They are marked below.
 class GMPVideoi420Frame : public GMPVideoFrame {
-public:
+ public:
   // MAIN THREAD ONLY
   // CreateEmptyFrame: Sets frame dimensions and allocates buffers based
   // on set dimensions - height and plane stride.
   // If required size is bigger than the allocated one, new buffers of adequate
   // size will be allocated.
   virtual GMPErr CreateEmptyFrame(int32_t aWidth, int32_t aHeight,
-                                  int32_t aStride_y, int32_t aStride_u, int32_t aStride_v) = 0;
+                                  int32_t aStride_y, int32_t aStride_u,
+                                  int32_t aStride_v) = 0;
 
   // MAIN THREAD ONLY
   // CreateFrame: Sets the frame's members and buffers. If required size is
@@ -72,8 +73,8 @@ public:
   virtual GMPErr CreateFrame(int32_t aSize_y, const uint8_t* aBuffer_y,
                              int32_t aSize_u, const uint8_t* aBuffer_u,
                              int32_t aSize_v, const uint8_t* aBuffer_v,
-                             int32_t aWidth, int32_t aHeight,
-                             int32_t aStride_y, int32_t aStride_u, int32_t aStride_v) = 0;
+                             int32_t aWidth, int32_t aHeight, int32_t aStride_y,
+                             int32_t aStride_u, int32_t aStride_v) = 0;
 
   // MAIN THREAD ONLY
   // Copy frame: If required size is bigger than allocated one, new buffers of
@@ -125,8 +126,9 @@ public:
   // Return true if underlying plane buffers are of zero size, false if not.
   virtual bool IsZeroSize() const = 0;
 
-  // Reset underlying plane buffers sizes to 0. This function doesn't clear memory.
+  // Reset underlying plane buffers sizes to 0. This function doesn't clear
+  // memory.
   virtual void ResetSize() = 0;
 };
 
-#endif // GMP_VIDEO_FRAME_I420_h_
+#endif  // GMP_VIDEO_FRAME_I420_h_

--- a/gmp-video-frame.h
+++ b/gmp-video-frame.h
@@ -36,16 +36,13 @@
 
 #include "gmp-video-plane.h"
 
-enum GMPVideoFrameFormat {
-  kGMPEncodedVideoFrame = 0,
-  kGMPI420VideoFrame = 1
-};
+enum GMPVideoFrameFormat { kGMPEncodedVideoFrame = 0, kGMPI420VideoFrame = 1 };
 
 class GMPVideoFrame {
-public:
+ public:
   virtual GMPVideoFrameFormat GetFrameFormat() = 0;
   // MAIN THREAD ONLY IF OWNING PROCESS
   virtual void Destroy() = 0;
 };
 
-#endif // GMP_VIDEO_FRAME_h_
+#endif  // GMP_VIDEO_FRAME_h_

--- a/gmp-video-host.h
+++ b/gmp-video-host.h
@@ -40,14 +40,14 @@
 #include "gmp-video-codec.h"
 
 // This interface must be called on the main thread only.
-class GMPVideoHost
-{
-public:
+class GMPVideoHost {
+ public:
   // Construct various video API objects. Host does not retain reference,
   // caller is owner and responsible for deleting.
   // MAIN THREAD ONLY
-  virtual GMPErr CreateFrame(GMPVideoFrameFormat aFormat, GMPVideoFrame** aFrame) = 0;
+  virtual GMPErr CreateFrame(GMPVideoFrameFormat aFormat,
+                             GMPVideoFrame** aFrame) = 0;
   virtual GMPErr CreatePlane(GMPPlane** aPlane) = 0;
 };
 
-#endif // GMP_VIDEO_HOST_h_
+#endif  // GMP_VIDEO_HOST_h_

--- a/gmp-video-plane.h
+++ b/gmp-video-plane.h
@@ -47,13 +47,12 @@
 // Methods that create or destroy shared memory must be called on the main
 // thread. They are marked below.
 class GMPPlane {
-public:
+ public:
   // MAIN THREAD ONLY
   // CreateEmptyPlane - set allocated size, actual plane size and stride:
   // If current size is smaller than current size, then a buffer of sufficient
   // size will be allocated.
-  virtual GMPErr CreateEmptyPlane(int32_t aAllocatedSize,
-                                  int32_t aStride,
+  virtual GMPErr CreateEmptyPlane(int32_t aAllocatedSize, int32_t aStride,
                                   int32_t aPlaneSize) = 0;
 
   // MAIN THREAD ONLY
@@ -63,7 +62,8 @@ public:
   // MAIN THREAD ONLY
   // Copy buffer: If current size is smaller
   // than current size, then a buffer of sufficient size will be allocated.
-  virtual GMPErr Copy(int32_t aSize, int32_t aStride, const uint8_t* aBuffer) = 0;
+  virtual GMPErr Copy(int32_t aSize, int32_t aStride,
+                      const uint8_t* aBuffer) = 0;
 
   // Swap plane data.
   virtual void Swap(GMPPlane& aPlane) = 0;
@@ -91,4 +91,4 @@ public:
   virtual void Destroy() = 0;
 };
 
-#endif // GMP_VIDEO_PLANE_h_
+#endif  // GMP_VIDEO_PLANE_h_


### PR DESCRIPTION
Largely style changes due to Mozilla central formatting rules changing.

We could probably remove gmp-sanitized-cdm-exports.h from the API and
hide it as an implementation detail. For now, keep it here so the API
mirrors the directory in Gecko, but consider removing it on the Gecko
side then updating this repo.