### PR TITLE
Remove missingFrames arg from GMP API

### DIFF
--- a/gmp-video-decode.h
+++ b/gmp-video-decode.h
@@ -93,15 +93,13 @@ class GMPVideoDecoder {
   // will be returned to the user through the decode complete callback.
   //
   // - aInputFrame: Frame to decode. Call Destroy() on frame when it's decoded.
-  // - aMissingFrames: True if one or more frames have been lost since the
-  //                   previous decode call.
   // - aCodecSpecificInfo : codec specific data, pointer to a
   //                        GMPCodecSpecificInfo structure appropriate for
   //                        this codec type.
   // - aCodecSpecificInfoLength : number of bytes in aCodecSpecificInfo
   // - renderTimeMs : System time to render in milliseconds. Only used by
   //                  decoders with internal rendering.
-  virtual void Decode(GMPVideoEncodedFrame* aInputFrame, bool aMissingFrames,
+  virtual void Decode(GMPVideoEncodedFrame* aInputFrame,
                       const uint8_t* aCodecSpecificInfo,
                       uint32_t aCodecSpecificInfoLength,
                       int64_t aRenderTimeMs = -1) = 0;


### PR DESCRIPTION
I'm removing this in Gecko. It's no longer used in libwebrtc, see https://issues.webrtc.org/issues/42225778.